### PR TITLE
Fix bug feature row enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Adheres to [Semantic Versioning](http://semver.org/).
 ## 1.2.3 (TBD)
 
 * TBD
+* Fix bug in feature row enumeration.
 
 ## [1.2.2](https://github.com/ngageoint/geopackage-ios/releases/tag/1.2.2) (06-14-2017)
 


### PR DESCRIPTION
* Store a strong reference to feature rows being enumerated.  countByEnumeratingWithState method returns weak unretained references
  to rows being enumerated.
* Update countByEnumeratingWithState to grab feature rows in bulk.