### PR TITLE
Release database connection after querying

### DIFF
--- a/geopackage-ios/db/GPKGConnection.m
+++ b/geopackage-ios/db/GPKGConnection.m
@@ -116,6 +116,7 @@
                                           andHaving:having
                                          andOrderBy:orderBy
                                            andLimit:limit];
+    [self.connectionPool releaseConnection:connection];
     return resultSet;
 }
 


### PR DESCRIPTION
I was sending multiple queries using the `-[GPKGFeatureIndexManager queryWithFieldValues:]` method, which, in my case, caused the `-[GPKGManualFeatureQuery queryWithDistinct:andColumns:andWhere:andWhereArgs:]` method to be invoked, and noticed that a new connection was opened for every query (as indicated by `GPKGConnectionPool.m:205`). When I then tried to write to the GeoPackage file using `-[GPKGFeatureDao insert:]`, I received a lock error (`GPKGConnectionPool.m:238`). Adding this line of code fixes the issue.